### PR TITLE
test: add Playwright E2E tests for contact form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -1239,6 +1240,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -3782,6 +3799,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './src/test/e2e',
+  timeout: 10_000,
+  retries: 0,
+  reporter: 'list',
+  use: {
+    baseURL: 'http://localhost:5173',
+    trace: 'off',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:5173',
+    reuseExistingServer: true,
+    timeout: 30_000,
+  },
+});

--- a/src/test/e2e/contact-form.spec.ts
+++ b/src/test/e2e/contact-form.spec.ts
@@ -1,0 +1,129 @@
+import { test, expect } from '@playwright/test';
+
+// The page contains TWO forms named "contact":
+//   1. A hidden static fallback in index.html (for Netlify build detection)
+//   2. The interactive React form (data-netlify="true")
+// All selectors must be scoped to the React form to avoid ambiguity.
+const FORM = 'form[data-netlify="true"]';
+
+test.describe('Contact form', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    const form = page.locator(FORM);
+    await form.scrollIntoViewIfNeeded();
+    await form.waitFor({ state: 'visible' });
+  });
+
+  // ── 1. Happy path ──────────────────────────────────────────────────────────
+  test('happy path — valid submission shows confirmation, form disappears', async ({ page }) => {
+    await page.route('**/*', async (route) => {
+      if (route.request().method() === 'POST' && new URL(route.request().url()).pathname === '/') {
+        await route.fulfill({ status: 200, body: '' });
+      } else {
+        await route.continue();
+      }
+    });
+
+    const form = page.locator(FORM);
+    await form.locator('input[name="name"]').fill('Jane Doe');
+    await form.locator('input[name="email"]').fill('jane@example.com');
+    await form.locator('textarea[name="message"]').fill('I would love to work with you on this role.');
+    await form.locator('button[type="submit"]').click();
+
+    await expect(page.getByText("Message sent! I'll reply within a day.")).toBeVisible({ timeout: 5_000 });
+    await expect(form.locator('input[name="name"]')).not.toBeVisible();
+    await expect(form.locator('textarea[name="message"]')).not.toBeVisible();
+  });
+
+  // ── 2. Empty submission ────────────────────────────────────────────────────
+  test('empty submission — browser validation blocks request, fields remain', async ({ page }) => {
+    let postMade = false;
+    await page.route('**/*', async (route) => {
+      if (route.request().method() === 'POST') postMade = true;
+      await route.continue();
+    });
+
+    const form = page.locator(FORM);
+    await form.locator('button[type="submit"]').click();
+    await page.waitForTimeout(300);
+
+    expect(postMade).toBe(false);
+    await expect(form.locator('button[type="submit"]')).toHaveText('SEND →');
+
+    const nameValid = await form.locator('input[name="name"]').evaluate(
+      (el: HTMLInputElement) => el.validity.valid
+    );
+    expect(nameValid).toBe(false);
+  });
+
+  // ── 3. Invalid email ───────────────────────────────────────────────────────
+  test('invalid email — browser validation blocks request', async ({ page }) => {
+    let postMade = false;
+    await page.route('**/*', async (route) => {
+      if (route.request().method() === 'POST') postMade = true;
+      await route.continue();
+    });
+
+    const form = page.locator(FORM);
+    await form.locator('input[name="name"]').fill('Jane Doe');
+    await form.locator('input[name="email"]').fill('not-an-email');
+    await form.locator('textarea[name="message"]').fill('Hello there.');
+    await form.locator('button[type="submit"]').click();
+    await page.waitForTimeout(300);
+
+    expect(postMade).toBe(false);
+    await expect(form.locator('button[type="submit"]')).toHaveText('SEND →');
+
+    const emailValid = await form.locator('input[name="email"]').evaluate(
+      (el: HTMLInputElement) => el.validity.valid
+    );
+    expect(emailValid).toBe(false);
+  });
+
+  // ── 4. Network failure ─────────────────────────────────────────────────────
+  test('network failure — shows error message and retry button', async ({ page }) => {
+    await page.route('**/*', async (route) => {
+      if (route.request().method() === 'POST' && new URL(route.request().url()).pathname === '/') {
+        await route.fulfill({ status: 500, body: 'Internal Server Error' });
+      } else {
+        await route.continue();
+      }
+    });
+
+    const form = page.locator(FORM);
+    await form.locator('input[name="name"]').fill('Jane Doe');
+    await form.locator('input[name="email"]').fill('jane@example.com');
+    await form.locator('textarea[name="message"]').fill('Hello there.');
+    await form.locator('button[type="submit"]').click();
+
+    await expect(page.getByText('Something went wrong. Try again.')).toBeVisible({ timeout: 5_000 });
+    await expect(form.locator('button[type="submit"]')).toHaveText('RETRY →');
+  });
+
+  // ── 5. Loading state ───────────────────────────────────────────────────────
+  test('loading state — button shows SENDING… while request is in flight', async ({ page }) => {
+    let unblock: () => void;
+    const blocker = new Promise<void>((resolve) => { unblock = resolve; });
+
+    await page.route('**/*', async (route) => {
+      if (route.request().method() === 'POST' && new URL(route.request().url()).pathname === '/') {
+        await blocker;
+        await route.fulfill({ status: 200, body: '' });
+      } else {
+        await route.continue();
+      }
+    });
+
+    const form = page.locator(FORM);
+    await form.locator('input[name="name"]').fill('Jane Doe');
+    await form.locator('input[name="email"]').fill('jane@example.com');
+    await form.locator('textarea[name="message"]').fill('Hello there.');
+    await form.locator('button[type="submit"]').click();
+
+    await expect(form.locator('button[type="submit"]')).toHaveText('SENDING…', { timeout: 3_000 });
+    await expect(form.locator('button[type="submit"]')).toBeDisabled();
+
+    unblock!();
+    await expect(page.getByText("Message sent! I'll reply within a day.")).toBeVisible({ timeout: 5_000 });
+  });
+});


### PR DESCRIPTION
Installs @playwright/test, adds playwright.config.ts targeting localhost:5173 (Chromium only), and covers 5 scenarios:

- Happy path: valid submission shows confirmation, form disappears
- Empty submission: browser validation blocks request
- Invalid email: browser validation blocks request
- Network failure: 500 response shows error message + retry
- Loading state: button shows SENDING… and is disabled in flight

All 5 pass. Form UI is correct; the submission bug was infrastructure (public/index.html overwriting dist/index.html at build time).